### PR TITLE
Rainbow text should not be overwritten.

### DIFF
--- a/rainbow.js
+++ b/rainbow.js
@@ -1,7 +1,7 @@
 (function($) {
-	$.fn.rainbow = function(options) {
+	$.fn.rainbow = function(_options) {
 		this.each(function() {
-		
+			var options = $.extend({}, _options);
 			options.originalText = $(this).html();
 			options.iterations = 0;
 			if (!options.pauseLength) {


### PR DESCRIPTION
But it is, if more than one element matches the selector. Everything will have it's text set to the last element's text:

http://jsfiddle.net/nzv2L259/ (thanks for this test case  @dguzek)

Although every unexpected feature makes this plugin even more awesome, let me fix this one.
